### PR TITLE
Voting stats in proposal component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -204,6 +204,13 @@
         "@types/node": "*",
         "bignumber.js": "~8.0.2",
         "ethereum-types": "^2.1.6"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.0.2.tgz",
+          "integrity": "sha512-EiuvFrnbv0jFixEQ9f58jo7X0qI2lNGIr/MxntmVzQc5JUweDSh8y8hbTCAomFtqwUPIOWcLXP0VEOSZTG7FFw=="
+        }
       }
     },
     "@0x/typescript-typings": {
@@ -218,6 +225,11 @@
         "popper.js": "1.14.3"
       },
       "dependencies": {
+        "bignumber.js": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.0.2.tgz",
+          "integrity": "sha512-EiuvFrnbv0jFixEQ9f58jo7X0qI2lNGIr/MxntmVzQc5JUweDSh8y8hbTCAomFtqwUPIOWcLXP0VEOSZTG7FFw=="
+        },
         "popper.js": {
           "version": "1.14.3",
           "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.3.tgz",
@@ -245,6 +257,11 @@
         "lodash": "^4.17.11"
       },
       "dependencies": {
+        "bignumber.js": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.0.2.tgz",
+          "integrity": "sha512-EiuvFrnbv0jFixEQ9f58jo7X0qI2lNGIr/MxntmVzQc5JUweDSh8y8hbTCAomFtqwUPIOWcLXP0VEOSZTG7FFw=="
+        },
         "js-sha3": {
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
@@ -5187,9 +5204,9 @@
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
     "bignumber.js": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.0.2.tgz",
-      "integrity": "sha512-EiuvFrnbv0jFixEQ9f58jo7X0qI2lNGIr/MxntmVzQc5JUweDSh8y8hbTCAomFtqwUPIOWcLXP0VEOSZTG7FFw=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
     },
     "binary-extensions": {
       "version": "2.1.0",
@@ -8341,6 +8358,13 @@
       "requires": {
         "@types/node": "*",
         "bignumber.js": "~8.0.2"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.0.2.tgz",
+          "integrity": "sha512-EiuvFrnbv0jFixEQ9f58jo7X0qI2lNGIr/MxntmVzQc5JUweDSh8y8hbTCAomFtqwUPIOWcLXP0VEOSZTG7FFw=="
+        }
       }
     },
     "ethereumjs-abi": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@web3-react/walletconnect-connector": "^6.1.4",
     "@web3-react/walletlink-connector": "^6.1.1",
     "async": "^3.2.0",
+    "bignumber.js": "^9.0.0",
     "flux": "^3.1.3",
     "i18next": "^19.6.2",
     "i18next-browser-languagedetector": "^4.3.1",

--- a/src/components/vote/proposal.jsx
+++ b/src/components/vote/proposal.jsx
@@ -24,9 +24,13 @@ import {
 } from '../../constants'
 
 import CopyIcon from '@material-ui/icons/FileCopy';
+import CancelIcon from '@material-ui/icons/Cancel';
+import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import WarningIcon from '@material-ui/icons/Warning';
 import { colors } from '../../theme'
 
 import Store from "../../stores";
+import { green, red, orange } from "@material-ui/core/colors";
 const emitter = Store.emitter
 const dispatcher = Store.dispatcher
 const store = Store.store
@@ -100,6 +104,18 @@ const styles = theme => ({
   heading: {
     flexShrink: 0
   },
+
+  votesHeading: {
+    display: 'none',
+    paddingTop: '12px',
+    flex: 1,
+    flexShrink: 0,
+    [theme.breakpoints.up('sm')]: {
+      paddingTop: '5px',
+      display: 'block'
+    }
+  },
+
   YIPheading: {
     width: '64px',
     flexShrink: 0
@@ -220,6 +236,27 @@ class Proposal extends Component {
     this.setState({ loading: false })
   };
 
+  votingMessage = (proposal) => {
+    let message;
+    if(proposal.myVotes > 0)
+      message = "You have voted " + proposal.direction + ".";
+    else
+      message = "You have not voted.";
+
+    if (proposal.canStillVote && proposal.myVotes === 0)
+      message += " Please vote now.";
+
+    return message;
+  };
+
+  formatVotes = (votes) => {
+    return (parseFloat(votes)/10**18).toLocaleString(undefined, { maximumFractionDigits: 4, minimumFractionDigits: 4 });
+  }
+
+  formatAsPercent = (ratio) => {
+    return (ratio * 100.0).toFixed(2).toLocaleString(undefined, { maximumFractionDigits: 4, minimumFractionDigits: 4 });
+  }
+
   render() {
     const { classes, proposal } = this.props;
     const {
@@ -284,6 +321,40 @@ class Proposal extends Component {
             <Typography variant={ 'h5' } className={ classes.grey }>Vote End: {proposal.end}</Typography>
           </div>
         </div>
+        <div className={ classes.assetSummary }>
+          <div className={classes.headingName}>
+            <div className={ classes.YIPheading }>
+              { proposal.myVotes > 0 && proposal.direction === "FOR" &&
+                <CheckCircleIcon style={{ fontSize: 30, color: green[500] }}/>
+              }
+              { proposal.myVotes > 0 && proposal.direction === "AGAINST" &&
+                <CancelIcon style={{ fontSize: 30, color: red[500] }} />
+              }
+              {
+                proposal.myVotes === 0 &&
+                <WarningIcon style={{ fontSize: 30, color: orange[500] }}/>
+              }
+            </div>
+            <div>
+              <div className={ classes.proposerAddressContainer }>
+                <Typography variant={'h3'}>{ this.votingMessage(proposal) }</Typography>
+              </div>
+              <Typography variant={ 'h5' } className={ classes.grey }>Status</Typography>
+            </div>
+          </div>
+          <div className={ classes.votesHeading }>
+            <Typography variant={ 'h3' }>{ this.formatVotes(proposal.myVotes) }</Typography>
+            <Typography variant={ 'h5' } className={ classes.grey }>Used votes</Typography>
+          </div>
+          <div className={ classes.votesHeading }>
+            <Typography variant={ 'h3' }>{ proposal.canStillVote ? this.formatVotes(proposal.availableVotes): 0 }</Typography>
+            <Typography variant={ 'h5' } className={ classes.grey }>Available votes</Typography>
+          </div>
+          <div className={ classes.votesHeading }>
+            <Typography variant={ 'h3' }>{ this.formatAsPercent(proposal.myVotesRatio) }%</Typography>
+            <Typography variant={ 'h5' } className={ classes.grey }>Participation weight</Typography>
+          </div>
+        </div>
         { proposal.end > currentBlock &&
           <div>
             { (governanceContractVersion === 2 && votingStatus !== true) &&
@@ -302,7 +373,7 @@ class Proposal extends Component {
                 </div>
               </div>
             }
-            { (governanceContractVersion !== 2 || votingStatus === true) &&
+            { (governanceContractVersion !== 2 || votingStatus === true) && proposal.canStillVote === true &&
               <div className={ classes.actionsContainer }>
                 <div className={ classes.tradeContainer }>
                   <Button

--- a/src/components/vote/proposal.jsx
+++ b/src/components/vote/proposal.jsx
@@ -325,14 +325,14 @@ class Proposal extends Component {
           <div className={classes.headingName}>
             <div className={ classes.YIPheading }>
               { proposal.myVotes > 0 && proposal.direction === "FOR" &&
-                <CheckCircleIcon style={{ fontSize: 30, color: green[500] }}/>
+                <CheckCircleIcon style={{ fontSize: 20, color: green[500] }}/>
               }
               { proposal.myVotes > 0 && proposal.direction === "AGAINST" &&
-                <CancelIcon style={{ fontSize: 30, color: red[500] }} />
+                <CancelIcon style={{ fontSize: 20, color: red[500] }} />
               }
               {
                 proposal.myVotes === 0 &&
-                <WarningIcon style={{ fontSize: 30, color: orange[500] }}/>
+                <WarningIcon style={{ fontSize: 20, color: orange[500] }}/>
               }
             </div>
             <div>

--- a/src/components/vote/vote.jsx
+++ b/src/components/vote/vote.jsx
@@ -20,6 +20,10 @@ import Snackbar from '../snackbar'
 import UnlockModal from '../unlock/unlockModal.jsx'
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import CopyIcon from '@material-ui/icons/FileCopy';
+import CancelIcon from '@material-ui/icons/Cancel';
+import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import WarningIcon from '@material-ui/icons/Warning';
+
 import Proposal from './proposal'
 
 import Store from "../../stores";
@@ -40,6 +44,9 @@ import {
   REGISTER_VOTE_RETURNED,
   REGISTER_VOTE
 } from '../../constants'
+import { green, red, orange } from "@material-ui/core/colors";
+
+
 
 const styles = theme => ({
   root: {
@@ -460,8 +467,21 @@ class Vote extends Component {
           >
             <div className={ classes.assetSummary }>
               <div className={classes.headingName}>
-                <div className={ classes.assetIcon }>
-                  <Typography variant={ 'h3' }>{ proposal.id }</Typography>
+                <div className={classes.heading}>
+                  <Typography variant={'h3'}>
+                    { proposal.myVotes > 0 && proposal.direction === "FOR" &&
+                      <CheckCircleIcon style={{ fontSize: 20, color: green[500] }}/>
+                    }
+                    { proposal.myVotes > 0 && proposal.direction === "AGAINST" &&
+                      <CancelIcon style={{ fontSize: 20, color: red[500] }} />
+                    }
+                    {
+                      proposal.myVotes === 0 &&
+                      <WarningIcon style={{ fontSize: 20, color: orange[500] }}/>
+                    }
+                    <span style={{ paddingLeft: 8}}>{ proposal.id }</span>
+                  </Typography>
+                  <Typography variant={ 'h5' } className={ classes.grey }>Vote Status</Typography>
                 </div>
                 <div>
                   <div className={ classes.proposerAddressContainer }>

--- a/src/utils/storageHelper.js
+++ b/src/utils/storageHelper.js
@@ -1,0 +1,17 @@
+import BigNumber from 'bignumber.js';
+
+// Do the storage lookup based on the contract layout in solidity:
+// https://solidity.readthedocs.io/en/v0.5.3/miscellaneous.html#layout-of-state-variables-in-storage
+async function findInStorage(web3, address, key, slot, increment) {
+  let newKey = web3.utils.soliditySha3({ type: "uint", value: key }, {type: "uint", value: slot});
+  newKey = increaseBy(newKey, increment);
+  let value = await web3.eth.getStorageAt(address, newKey);
+  return { newKey, value };
+}
+
+function increaseBy(hex, n) {
+  let sum = new BigNumber(hex).plus(n);
+  return '0x' + sum.toString(16);
+}
+
+export default findInStorage;

--- a/src/utils/voteFinder.js
+++ b/src/utils/voteFinder.js
@@ -1,0 +1,45 @@
+import BigNumber from 'bignumber.js';
+import findInStorage from './storageHelper.js';
+
+function toNumber(hex) {
+  return new BigNumber(hex).toNumber();
+}
+/**
+  Trying to find the current votes for a wallet. The user has either voted FOR or AGAINST or has not yet voted at all.
+  We have to find the right proposal struct from the proposals mapping on-chain and extract the forVotes and againstVotes mappings.
+  Once we have the mappings we can look up the votes and because the contract guarantees that a wallet can be either only FOR or only AGAINST a YIP.
+  We can extract the votes and return them to the frontend components.
+ */
+async function getMyVotes(web3, contractAddress, walletAddress, proposalId) {
+  // slot number for proposals mapping that we have to unpack. it's magic.
+  let proposalsSlot = 6;
+
+  // forVotes is at index 2
+  let { newKey: forVotesKey } = await findInStorage(web3, contractAddress, proposalId, proposalsSlot, 2);
+  // againstVotes is at index 3
+  let { newKey: againstVotesKey } = await findInStorage(web3, contractAddress, proposalId, proposalsSlot, 3);
+
+  // get the forVotes values for the current wallet
+  let { value: forVotes } = await findInStorage(web3, contractAddress, walletAddress, forVotesKey, 0);
+
+  // get the againstVotes values for the current wallet
+  let { value: againstVotes } = await findInStorage(web3, contractAddress, walletAddress, againstVotesKey, 0);
+
+  let votes = 0;
+  let direction = "NONE";
+
+  if (forVotes > 0) {
+    votes = forVotes;
+    direction = "FOR";
+  } else if (againstVotes > 0) {
+    votes = againstVotes;
+    direction = "AGAINST";
+  }
+
+  return {
+    myVotes: toNumber(votes),
+    direction
+  };
+}
+
+export default getMyVotes;


### PR DESCRIPTION
This adds some stats about past and ongoing YIPs to the proposals component. Could be helpful for users like me who forget if they have voted already for a YIP or not :joy:

I've gone the ugly path via ETH storage because I couldn't find another way to access my current votes on-chain through the public interfaces provided in the yGOV contract. Maybe there's an easier way to do the same thing ?

Works on my wallet, please have a look :sweat_smile: