### PR TITLE
Enable claim button when the governance breaker is to true

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Local settings
+.vscode

--- a/src/components/stake/stake.jsx
+++ b/src/components/stake/stake.jsx
@@ -294,6 +294,7 @@ class Stake extends Component {
 
   govRequirementsReturned = (requirements) => {
     this.setState({
+      gov_breakerEnabled: requirements.breakerEnabled,
       gov_voteLockValid: requirements.voteLockValid,
       gov_voteLock: requirements.voteLock
     })
@@ -397,6 +398,7 @@ class Stake extends Component {
       voteLockValid,
       balanceValid,
       voteLock,
+      gov_breakerEnabled,
       gov_voteLockValid,
       gov_voteLock,
     } = this.state
@@ -422,7 +424,7 @@ class Stake extends Component {
             className={ classes.actionButton }
             variant="outlined"
             color="primary"
-            disabled={ loading || (['GovernanceV2'].includes(pool.id) && !gov_voteLockValid) }
+            disabled={ loading || (['GovernanceV2'].includes(pool.id) && !gov_voteLockValid && !gov_breakerEnabled) }
             onClick={ () => { this.onClaim() } }
             >
             <Typography className={ classes.buttonText } variant={ 'h4'}>Claim Rewards</Typography>

--- a/src/components/stake/stake.jsx
+++ b/src/components/stake/stake.jsx
@@ -457,7 +457,7 @@ class Stake extends Component {
           }
         </div>
         { (['Governance', 'GovernanceV2'].includes(pool.id) && voteLockValid) && <Typography variant={'h4'} className={ classes.voteLockMessage }>Unstaking tokens only allowed once all your pending votes have closed at Block: {voteLock}</Typography> }
-        { (['GovernanceV2'].includes(pool.id) && !gov_voteLockValid) && <Typography variant={'h4'} className={ classes.voteLockMessage }>You need to have voted recently in order to claim rewards</Typography> }
+        { (['GovernanceV2'].includes(pool.id) && !gov_voteLockValid  && !gov_breakerEnabled) && <Typography variant={'h4'} className={ classes.voteLockMessage }>You need to have voted recently in order to claim rewards</Typography> }
         { (['GovernanceV2'].includes(pool.id) && gov_voteLockValid) && <Typography variant={'h4'} className={ classes.voteLockMessage }>You have recently voted, you can unstake at block {gov_voteLock}</Typography> }
       </div>
     )

--- a/src/stores/store.jsx
+++ b/src/stores/store.jsx
@@ -1254,11 +1254,13 @@ class Store {
       const web3 = new Web3(store.getStore('web3context').library.provider);
 
       const governanceContract = new web3.eth.Contract(config.governanceV2ABI,config.governanceV2Address)
-
+      
+      const breaker = await governanceContract.methods.breaker().call()
       const voteLock = await governanceContract.methods.voteLock(account.address).call({ from: account.address })
       const currentBlock = await web3.eth.getBlockNumber()
-
+    
       const returnOBJ = {
+        breakerEnabled: breaker,
         voteLockValid: voteLock > currentBlock,
         voteLock: voteLock
       }


### PR DESCRIPTION
This PR adds the breaker return value to the returned contract State, and passes it to the component that manages when the claim button is disabled.

When the breaker is enabled, the button is also enabled to allow withdrawals.